### PR TITLE
add: player post interface

### DIFF
--- a/backend/cmd/api/errors.go
+++ b/backend/cmd/api/errors.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// helper method for logging an error message along with current request
+func (app *application) logError(r *http.Request, err error) {
+	var (
+		method = r.Method
+		uri    = r.URL.RequestURI()
+	)
+
+	app.logger.Error(err.Error(), "method", method, "uri", uri)
+}
+
+// JSON formatted error messages, using any type as the message
+func (app *application) errorResponse(w http.ResponseWriter, r *http.Request, status int, message any) {
+	env := envelope{
+		"error": message,
+	}
+
+	// Fall back to raw 500 if writing the error fails
+	err := app.writeJSON(w, status, env, nil)
+	if err != nil {
+		app.logError(r, err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+// Send a 500, log the request and send the user a generic JSON response
+func (app *application) serverErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
+	app.logError(r, err)
+
+	message := "the server encountered a problem and could not process your request"
+	app.errorResponse(w, r, http.StatusInternalServerError, message)
+}
+
+// Send a 404, log the request and send the user a generic JSON response
+func (app *application) notFoundResponse(w http.ResponseWriter, r *http.Request) {
+	message := "the requested resource could not be found"
+	app.errorResponse(w, r, http.StatusNotFound, message)
+}
+
+// Send a 405, log the request and send the user a generic JSON response
+func (app *application) methodNotAllowedResponse(w http.ResponseWriter, r *http.Request) {
+	message := fmt.Sprintf("the %s method is not supported for this resouce", r.Method)
+	app.errorResponse(w, r, http.StatusMethodNotAllowed, message)
+}
+
+// Send a 400, log the request and send the user a generic JSON response
+func (app *application) badRequestResponse(w http.ResponseWriter, r *http.Request, err error) {
+	app.errorResponse(w, r, http.StatusBadRequest, err.Error())
+}

--- a/backend/cmd/api/helpers.go
+++ b/backend/cmd/api/helpers.go
@@ -3,8 +3,11 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -40,6 +43,56 @@ func (app *application) writeJSON(w http.ResponseWriter, status int, data envelo
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	w.Write(js)
+
+	return nil
+}
+
+func (app *application) readJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	// limit body to 1MB
+	r.Body = http.MaxBytesReader(w, r.Body, 1_048_576)
+
+	// initialize the decoder and call DisallowUnknownFields() method on it
+	// if field doesn't map to a struct it will return an error
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(dst)
+	if err != nil {
+		var syntaxError *json.SyntaxError
+		var unmarshTypeError *json.UnmarshalTypeError
+		var invalidUnmarshalError *json.InvalidUnmarshalError
+		var MaxBytesError *http.MaxBytesError
+
+		switch {
+		case errors.As(err, &syntaxError):
+			return fmt.Errorf("body contains badly-formed JSON (at character %d)", syntaxError.Offset)
+		// using .Is here to match a specific error not matching a type
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			return errors.New("body contains badly-formed JSON")
+		case errors.As(err, &unmarshTypeError):
+			if unmarshTypeError.Field != "" {
+				return fmt.Errorf("body contains incorrect JSON type for field %q", unmarshTypeError.Field)
+			}
+			return fmt.Errorf("body contains incorrect JSON type (at character %d)", unmarshTypeError.Offset)
+		case errors.Is(err, io.EOF):
+			return errors.New("body must not be empty")
+		case strings.HasPrefix(err.Error(), "json: unknown field"):
+			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field")
+			return fmt.Errorf("body contains an unknown key %s", fieldName)
+		case errors.As(err, &MaxBytesError):
+			return fmt.Errorf("body must not be larger than %d bytes", MaxBytesError.Limit)
+		case errors.As(err, &invalidUnmarshalError):
+			panic(err)
+
+		default:
+			return err
+		}
+	}
+
+	err = dec.Decode(&struct{}{})
+	if !errors.Is(err, io.EOF) {
+		return errors.New("body must only contain a single JSON value")
+	}
 
 	return nil
 }

--- a/backend/cmd/api/middleware.go
+++ b/backend/cmd/api/middleware.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (app *application) recoverPanic(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			pv := recover()
+			if pv != nil {
+				w.Header().Set("Connection", "close")
+				app.serverErrorResponse(w, r, fmt.Errorf("%v", pv))
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/cmd/api/players.go
+++ b/backend/cmd/api/players.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -10,13 +11,13 @@ import (
 func (app *application) showPlayerHandler(w http.ResponseWriter, r *http.Request) {
 	id, err := app.readIDParam(r)
 	if err != nil {
-		app.logger.Error(err.Error())
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		app.serverErrorResponse(w, r, err)
+		return
 	}
 
 	// tmp dummy data
 	if id != 1 {
-		w.Write([]byte(`{"status": "error"}`))
+		app.notFoundResponse(w, r)
 		return
 	}
 
@@ -28,7 +29,7 @@ func (app *application) showPlayerHandler(w http.ResponseWriter, r *http.Request
 		LastName:      "McDavid",
 		SweaterNumber: 97,
 		Position:      data.PositionC,
-		BirthDate: data.Date{
+		BirthDate: data.BirthDate{
 			Time: time.Date(1997, 1, 13, 0, 0, 0, 0, time.UTC),
 		},
 		Headshot: "https://assets/path/to/headshot.png",
@@ -82,7 +83,31 @@ func (app *application) showPlayerHandler(w http.ResponseWriter, r *http.Request
 
 	err = app.writeJSON(w, http.StatusOK, envelope{"player": skater}, nil)
 	if err != nil {
-		app.logger.Error(err.Error())
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		app.serverErrorResponse(w, r, err)
 	}
+}
+
+func (app *application) createPlayerHandler(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		IsActive      bool `json:"is_active"`
+		CurrentTeamId int  `json:"current_team_id"`
+
+		FirstName     string             `json:"first_name"`
+		LastName      string             `json:"last_name"`
+		SweaterNumber uint8              `json:"sweater_number"`
+		Position      data.Position      `json:"position"`
+		BirthDate     data.BirthDate     `json:"birth_date"`
+		BirthCountry  string             `json:"birth_country"`
+		Headshot      string             `json:"headshot,omitzero"`
+		ShootsCatches data.ShootsCatches `json:"shoots_catches,omitzero"`
+	}
+
+	err := app.readJSON(w, r, &input)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	fmt.Fprintln(w, "Success!")
+	fmt.Fprintf(w, "%v\n", input)
 }

--- a/backend/cmd/api/routes.go
+++ b/backend/cmd/api/routes.go
@@ -9,8 +9,12 @@ import (
 func (app *application) routes() http.Handler {
 	router := httprouter.New()
 
+	router.NotFound = http.HandlerFunc(app.notFoundResponse)
+	router.MethodNotAllowed = http.HandlerFunc(app.methodNotAllowedResponse)
+
 	router.HandlerFunc(http.MethodGet, "/v1/healthcheck", app.healthcheckHandler)
 	router.HandlerFunc(http.MethodGet, "/v1/players/:id", app.showPlayerHandler)
+	router.HandlerFunc(http.MethodPost, "/v1/players", app.createPlayerHandler)
 
-	return router
+	return app.recoverPanic(router)
 }

--- a/backend/internal/data/date.go
+++ b/backend/internal/data/date.go
@@ -1,34 +1,39 @@
 package data
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
 
-type Date struct {
+var ErrInvalidDateFormat = errors.New("invalid date format, expected: 2006-01-30")
+
+type BirthDate struct {
 	time.Time
 }
 
-func (d *Date) UnmarshalJSON(b []byte) error {
+func (d *BirthDate) UnmarshalJSON(b []byte) error {
 	s := strings.Trim(string(b), `"`)
 	t, err := time.Parse("2006-01-02", s)
 	if err != nil {
-		return err
+		return ErrInvalidDateFormat
 	}
 	d.Time = t
 	return nil
 }
 
-func (d Date) MarshalJSON() ([]byte, error) {
+func (d BirthDate) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + d.Format("2006-01-02") + `"`), nil
 }
+
+var ErrInvalidTimeOnIceFormat = errors.New("invalid time ice format, expected: MM:SS")
 
 type TimeOnIce struct {
 	time.Duration
 }
 
-// need to write Decode still
 func (t TimeOnIce) MarshalJSON() ([]byte, error) {
 	if t.Duration <= 0 {
 		return []byte(`"00:00"`), nil
@@ -40,4 +45,17 @@ func (t TimeOnIce) MarshalJSON() ([]byte, error) {
 
 	var b []byte
 	return fmt.Appendf(b, `"%02d:%02d"`, mins, secs), nil
+}
+
+// WIP
+func (t *TimeOnIce) UnmarshalJSON(jsonValue []byte) error {
+	unquotedJSONValue, err := strconv.Unquote(string(jsonValue))
+	if err != nil {
+		return ErrInvalidTimeOnIceFormat
+	}
+
+	parts := strings.Split(unquotedJSONValue, ":")
+
+	_ = parts
+	return nil
 }

--- a/backend/internal/data/players.go
+++ b/backend/internal/data/players.go
@@ -1,20 +1,8 @@
 package data
 
-type Position string
-
-const (
-	PositionC  Position = "C"
-	PositionLW Position = "LW"
-	PositionRW Position = "RW"
-	PositionD  Position = "D"
-	PositionG  Position = "G"
-)
-
-type ShootsCatches string
-
-const (
-	ShootsCatchesL ShootsCatches = "L"
-	ShootsCatchesR ShootsCatches = "R"
+import (
+	"encoding/json"
+	"errors"
 )
 
 type Player struct {
@@ -22,17 +10,16 @@ type Player struct {
 	IsActive      bool `json:"is_active"`
 	CurrentTeamId int  `json:"current_team_id"`
 
-	FirstName     string        `json:"first_name"`
-	LastName      string        `json:"last_name"`
-	SweaterNumber uint8         `json:"sweater_number"`
-	Position      Position      `json:"position"`
-	BirthDate     Date          `json:"birth_date"`    // force format 1995-04-22
-	BirthCountry  string        `json:"birth_country"` // "CAN"
-	Headshot      string        `json:"headshot,omitzero"`
-	ShootsCatches ShootsCatches `json:"shoots_catches,omitzero"`
-	// "playerSlug": "philipp-grubauer-8475831", // optional, derive at call time
-	SkaterStats *SkaterStatSet `json:"skater_stats,omitzero"`
-	GoalieStats *GoalieStatSet `json:"goalie_stats,omitzero"`
+	FirstName     string         `json:"first_name"`
+	LastName      string         `json:"last_name"`
+	SweaterNumber uint8          `json:"sweater_number"`
+	Position      Position       `json:"position"`
+	BirthDate     BirthDate      `json:"birth_date"`
+	BirthCountry  string         `json:"birth_country"`
+	Headshot      string         `json:"headshot,omitzero"`
+	ShootsCatches ShootsCatches  `json:"shoots_catches,omitzero"`
+	SkaterStats   *SkaterStatSet `json:"skater_stats,omitzero"`
+	GoalieStats   *GoalieStatSet `json:"goalie_stats,omitzero"`
 }
 
 type SeasonSplit[T any] struct {
@@ -48,4 +35,57 @@ type SkaterStatSet struct {
 type GoalieStatSet struct {
 	CurrentStats SeasonSplit[GoalieStats] `json:"current_stats,omitzero"`
 	CareerTotals SeasonSplit[GoalieStats] `json:"career_totals,omitzero"`
+}
+
+var ErrInvalidPositionFormat = errors.New("invalid position format, expected: C|LW|RW|D|G")
+
+type Position string
+
+const (
+	PositionC  Position = "C"
+	PositionLW Position = "LW"
+	PositionRW Position = "RW"
+	PositionD  Position = "D"
+	PositionG  Position = "G"
+)
+
+func (p *Position) UnmarshalJSON(jsonValue []byte) error {
+	var s string
+	if err := json.Unmarshal(jsonValue, &s); err != nil {
+		return ErrInvalidPositionFormat
+	}
+
+	pos := Position(s)
+	switch pos {
+	case PositionC, PositionLW, PositionRW, PositionD, PositionG:
+		*p = pos
+		return nil
+	}
+
+	return ErrInvalidPositionFormat
+}
+
+var ErrInvalidShootCatches = errors.New("invalid position format, expected: L|R")
+
+type ShootsCatches string
+
+const (
+	ShootsCatchesL ShootsCatches = "L"
+	ShootsCatchesR ShootsCatches = "R"
+)
+
+func (sc *ShootsCatches) UnmarshalJSON(jsonValue []byte) error {
+	var s string
+	if err := json.Unmarshal(jsonValue, &s); err != nil {
+		return ErrInvalidPositionFormat
+	}
+
+	shct := ShootsCatches(s)
+	switch shct {
+	case ShootsCatchesL, ShootsCatchesR:
+		*sc = shct
+		return nil
+	}
+
+	return ErrInvalidShootCatches
 }


### PR DESCRIPTION
Adds a poster interface for: `POST /v1/players`

Example request:
```json
{
  "first_name": "Connor",
  "last_name": "McDavid",
  "sweater_number": 97,
  "position": "C",
  "birth_date": "1997-01-13",
  "birth_country": "CAN",
  "shoots_catches": "L"
}
```