### PR TITLE
add: methods to return players with team info

### DIFF
--- a/backend/cmd/api/players.go
+++ b/backend/cmd/api/players.go
@@ -17,7 +17,7 @@ func (app *application) showPlayerHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	player, err := app.models.Players.Get(id)
+	player, err := app.models.Players.GetWithTeam(id)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrRecordNotFound):
@@ -67,13 +67,19 @@ func (app *application) listPlayersHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	players, metadata, err := app.models.Players.GetAll(input.FirstName, input.LastName, input.Position, input.Filters)
+	// players, metadata, err := app.models.Players.GetAll(input.FirstName, input.LastName, input.Position, input.Filters)
+	// if err != nil {
+	// 	app.serverErrorResponse(w, r, err)
+	// 	return
+	// }
+
+	players, err := app.models.Players.GetAllWithTeam()
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 
-	err = app.writeJSON(w, http.StatusOK, envelope{"players": players, "metadata": metadata}, nil)
+	err = app.writeJSON(w, http.StatusOK, envelope{"players": players}, nil)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 	}
@@ -82,7 +88,7 @@ func (app *application) listPlayersHandler(w http.ResponseWriter, r *http.Reques
 func (app *application) createPlayerHandler(w http.ResponseWriter, r *http.Request) {
 	var input struct {
 		IsActive      bool `json:"is_active"`
-		CurrentTeamId *int `json:"current_team_id"`
+		CurrentTeamId int  `json:"current_team_id"`
 
 		FirstName     string             `json:"first_name"`
 		LastName      string             `json:"last_name"`
@@ -177,7 +183,7 @@ func (app *application) updatePlayerHandler(w http.ResponseWriter, r *http.Reque
 		player.IsActive = *input.IsActive
 	}
 	if input.CurrentTeamId != nil {
-		player.CurrentTeamID = input.CurrentTeamId
+		player.CurrentTeamID = *input.CurrentTeamId
 	}
 	if input.FirstName != nil {
 		player.FirstName = *input.FirstName

--- a/backend/internal/data/players.go
+++ b/backend/internal/data/players.go
@@ -16,7 +16,7 @@ type Player struct {
 	Version   int       `json:"version"`
 
 	IsActive      bool `json:"is_active"`
-	CurrentTeamID *int `json:"current_team_id"`
+	CurrentTeamID int  `json:"current_team_id"`
 
 	FirstName     string        `json:"first_name"`
 	LastName      string        `json:"last_name"`
@@ -89,7 +89,7 @@ func (m PlayerModel) Get(id int) (*Player, error) {
 		return nil, ErrRecordNotFound
 	}
 
-	query := `
+	query := /* sql */ `
 		SELECT 
 			id,
 			is_active,
@@ -237,8 +237,6 @@ func (m PlayerModel) Update(player *Player) error {
 		player.Version,
 	}
 
-	fmt.Println(player.ID, player.Version)
-
 	err := m.DB.QueryRow(query, args...).Scan(&player.Version)
 	if err != nil {
 		switch {
@@ -272,8 +270,130 @@ func (m PlayerModel) Delete(id int) error {
 	}
 
 	if rowsAffected == 0 {
-		return err
+		return ErrRecordNotFound
 	}
 
 	return nil
+}
+
+type PlayerWithTeam struct {
+	Player
+	TeamFullName  string `json:"team_full_name"`
+	TeamShortName string `json:"team_short_name"`
+}
+
+func (m PlayerModel) GetWithTeam(id int) (*PlayerWithTeam, error) {
+	query := /* sql */ `
+		SELECT
+			p.id,
+			p.is_active,
+			p.current_team_id,
+			p.first_name,
+			p.last_name,
+			p.sweater_number,
+			p.position,
+			p.birth_date,
+			p.birth_country,
+			p.headshot,
+			p.shoots_catches,
+			p.version,
+			t.full_name,
+			t.short_name
+		FROM players p
+		INNER JOIN teams t
+			ON p.current_team_id = t.id
+		WHERE p.id = $1
+	`
+
+	var p PlayerWithTeam
+
+	err := m.DB.QueryRow(query, id).Scan(
+		&p.ID,
+		&p.IsActive,
+		&p.CurrentTeamID,
+		&p.FirstName,
+		&p.LastName,
+		&p.SweaterNumber,
+		&p.Position,
+		&p.BirthDate,
+		&p.BirthCountry,
+		&p.Headshot,
+		&p.ShootsCatches,
+		&p.Version,
+		&p.TeamFullName,
+		&p.TeamShortName,
+	)
+
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return nil, ErrRecordNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return &p, nil
+}
+
+func (m PlayerModel) GetAllWithTeam() ([]*PlayerWithTeam, error) {
+	query := /* sql */ `
+		SELECT
+			p.id,
+			p.is_active,
+			p.current_team_id,
+			p.first_name,
+			p.last_name,
+			p.sweater_number,
+			p.position,
+			p.birth_date,
+			p.birth_country,
+			p.headshot,
+			p.shoots_catches,
+			p.version,
+			t.full_name,
+			t.short_name
+		FROM players p
+		INNER JOIN teams t
+			ON p.current_team_id = t.id
+	`
+
+	rows, err := m.DB.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	players := []*PlayerWithTeam{}
+
+	for rows.Next() {
+		var p PlayerWithTeam
+		err = rows.Scan(
+			&p.ID,
+			&p.IsActive,
+			&p.CurrentTeamID,
+			&p.FirstName,
+			&p.LastName,
+			&p.SweaterNumber,
+			&p.Position,
+			&p.BirthDate,
+			&p.BirthCountry,
+			&p.Headshot,
+			&p.ShootsCatches,
+			&p.Version,
+			&p.TeamFullName,
+			&p.TeamShortName,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		players = append(players, &p)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return players, err
 }

--- a/backend/internal/data/teams.go
+++ b/backend/internal/data/teams.go
@@ -72,10 +72,13 @@ func (m TeamModel) Insert(team *Team) error {
 }
 
 func (m TeamModel) Delete(id int) error {
+	if id < 1 {
+		return ErrRecordNotFound
+	}
+
 	query := /* sql */ `
 		DELETE FROM teams
-		WHERE id = $1
-	`
+		WHERE id = $1`
 
 	result, err := m.DB.Exec(query, id)
 	if err != nil {
@@ -88,7 +91,7 @@ func (m TeamModel) Delete(id int) error {
 	}
 
 	if rowsAffected == 0 {
-		return err
+		return ErrRecordNotFound
 	}
 
 	return nil
@@ -101,7 +104,8 @@ func (m TeamModel) GetAll() ([]*Team, error) {
 			id,
 			full_name,
 			short_name,
-			division_id
+			division_id,
+			is_active
 		FROM teams;`
 
 	rows, err := m.DB.Query(query)
@@ -119,6 +123,7 @@ func (m TeamModel) GetAll() ([]*Team, error) {
 			&t.FullName,
 			&t.ShortName,
 			&t.DivisionID,
+			&t.IsActive,
 		)
 		if err != nil {
 			return nil, err

--- a/db/migrations/000002_create_players_table.up.sql
+++ b/db/migrations/000002_create_players_table.up.sql
@@ -2,9 +2,9 @@ CREATE TABLE IF NOT EXISTS players (
     id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     created_at timestamp(0) with time zone NOT NULL DEFAULT NOW(),
     is_active boolean NOT NULL DEFAULT false,
-    current_team_id bigint
+    current_team_id bigint NOT NULL
         REFERENCES teams(id)
-        ON DELETE SET NULL,
+        ON DELETE RESTRICT,
     first_name text NOT NULL,
     last_name text NOT NULL,
     sweater_number smallint NOT NULL


### PR DESCRIPTION
Some slight coupling and domain overlap in `internal/data/players.go` that I'm not confident about yet.
It feels like the best way right now to make make multiple database connections for such a common pull

Reverted allow null, not sure it's best for now, need to evaluate further.